### PR TITLE
Force use of Python3

### DIFF
--- a/bin/gimme-aws-creds.cmd
+++ b/bin/gimme-aws-creds.cmd
@@ -5,7 +5,7 @@ set PythonExe=""
 set PythonExeFlags=
 
 for %%i in (cmd bat exe) do (
-    for %%j in (python.%%i) do (
+    for %%j in (python3.%%i) do (
         call :SetPythonExe "%%~$PATH:j"
     )
 )


### PR DESCRIPTION
Execution fails the import if Python 2 is also installed and higher in Windows Path.  Changing the PythonExe to match Python3 instead forces a working version.

<!--- Provide a general summary of your changes in the Title above -->
Trivial change to select python3.exe as the PythonExe variable.
## Description
<!--- Describe your changes in detail -->
Execution fails the import if Python 2 is also installed and higher in Windows Path.  Changing the PythonExe to match Python3 instead forces a working version.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/Nike-Inc/gimme-aws-creds/issues/178

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
When clients have multiple major versions of Python installed it ensures the compatible version is chosen.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> Manually updated the cmd script on multiple systems with different versions of Python installed, and different order for path priority
<!--- Include details of your testing environment, and the tests you ran to --> Windows 10, manually running gimme-aws-creds for configuration and normal credentials recovery.
<!--- see how your change affects other areas of the code, etc. -->
No other changes discerned or expected.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
The existing tests do not test the cmd script, but failed on my test workstations as python2 would run and fail on line 6 of test_main.py: 
from gimme_aws_creds.main import GimmeAWSCreds